### PR TITLE
Support alternatives 'X' and '=' in CIGAR string

### DIFF
--- a/PredictHaplo_externAlign.cpp
+++ b/PredictHaplo_externAlign.cpp
@@ -20,6 +20,7 @@
 #define R_finite(x) std::isfinite(x)
 
 #include "phaplo/median.hpp"
+#include "phaplo/is_alignment_match.hpp"
 #include "scythestat/distributions.h"
 #include "scythestat/ide.h"
 #include "scythestat/la.h"
@@ -171,7 +172,7 @@ int parse_sam_line(const vector<string> &tokens, string &used_qual,
         c++;
       }
 
-    if (symbols[i] == 'M')
+    if (phaplo::is_alignment_match(symbols[i]))
       for (int j = 0; j < sub_length_vec[i]; j++) {
         int k = 0;
         if (tokens[9][c] == 'A' || tokens[9][c] == 'a')
@@ -530,7 +531,7 @@ int parseSAM(string al, double max_gap_fraction,
               c++;
             }
 
-          if (symbols[i] == 'M')
+          if (phaplo::is_alignment_match(symbols[i]))
             for (int j = 0; j < sub_length_vec[i]; j++) {
               int k = 0;
               if (tokens[9][c] == 'A' || tokens[9][c] == 'a')

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 add_library(phaplo
   median.cpp
+  is_alignment_match.cpp
 )
 target_include_directories(phaplo
   PUBLIC

--- a/lib/include/phaplo/is_alignment_match.hpp
+++ b/lib/include/phaplo/is_alignment_match.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 ETH Zurich
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace phaplo {
+
+/**
+ * @brief Returns whether the character `c` represents an alignment match
+ * (CIGAR).
+ */
+bool is_alignment_match(const char c) noexcept;
+
+} // namespace phaplo

--- a/lib/is_alignment_match.cpp
+++ b/lib/is_alignment_match.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 ETH Zurich
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <phaplo/is_alignment_match.hpp>
+
+namespace phaplo {
+
+bool is_alignment_match(const char c) noexcept {
+  switch (c) {
+  case 'M':
+  case 'X':
+  case '=':
+    return true;
+  }
+  return false;
+}
+
+} // namespace phaplo

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(GTest 1.10 MODULE REQUIRED)
 add_executable(
   phaplo_Tests
   median_Test.cpp
+  is_alignment_match_Test.cpp
 )
 target_link_libraries(
   phaplo_Tests

--- a/lib/tests/is_alignment_match_Test.cpp
+++ b/lib/tests/is_alignment_match_Test.cpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 ETH Zurich
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <phaplo/is_alignment_match.hpp>
+
+namespace phaplo {
+namespace {
+struct is_alignment_match_Test : ::testing::Test {};
+
+TEST_F(is_alignment_match_Test, M_represents_alignment_match) {
+  EXPECT_TRUE(is_alignment_match('M'));
+}
+
+TEST_F(is_alignment_match_Test, X_represents_alignment_match) {
+  EXPECT_TRUE(is_alignment_match('X'));
+}
+
+TEST_F(is_alignment_match_Test, equal_sign_represents_alignment_match) {
+  EXPECT_TRUE(is_alignment_match('='));
+}
+
+TEST_F(is_alignment_match_Test, D_does_not_represent_alignment_match) {
+  EXPECT_FALSE(is_alignment_match('D'));
+}
+
+TEST_F(is_alignment_match_Test, m_does_not_represent_alignment_match) {
+  EXPECT_FALSE(is_alignment_match('m'));
+}
+} // namespace
+} // namespace phaplo


### PR DESCRIPTION
- interpret 'M', 'X', and '=' as alignment match